### PR TITLE
Fixes to navigation paths

### DIFF
--- a/lib/Plerd/Init.pm
+++ b/lib/Plerd/Init.pm
@@ -376,12 +376,12 @@ wrapper => <<EOF,
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="recent.html">[% plerd.title %]</a>
+                <a class="navbar-brand" href="/recent.html">[% plerd.title %]</a>
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
-                    <li><a href="archive.html">Archive</a></li>
-                    <li><a href="atom.xml">RSS</a></li>
+                    <li><a href="/archive.html">Archive</a></li>
+                    <li><a href="/atom.xml">RSS</a></li>
                 </ul>
             </div><!--/.navbar-collapse -->
         </div>


### PR DESCRIPTION
Fixed site navigation links on Tag pages which were producing 404 errors because tag pages are in a subdirectory.